### PR TITLE
Add CI and releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+# Source: https://daniellockyer.com/automated-rust-releases/
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    name: Publish for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        name: [
+          linux,
+          windows,
+          macos
+        ]
+        include:
+          - name: linux
+            os: ubuntu-latest
+            artifact_name: pocket
+            asset_name: pocket-linux
+          - name: windows
+            os: windows-latest
+            artifact_name: pocket.exe
+            asset_name: pocket-windows
+          - name: macos
+            os: macos-latest
+            artifact_name: pocket
+            asset_name: pocket-macos
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Build
+        run: cargo build --release --locked
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/release/${{ matrix.artifact_name }}
+          asset_name: ${{ matrix.asset_name }}
+          tag: ${{ github.ref }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,65 @@
+# Source: https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
+name: Verify
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pocket"
+version = "0.1.0"
+dependencies = [
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pocket 0.1.3 (git+https://github.com/ozbe/rust-pocket.git)",
+ "structopt 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pocket"
 version = "0.1.3"
 source = "git+https://github.com/ozbe/rust-pocket.git#5c2e15babeafefae6ab0f0744309c5171d0b6fd7"
 dependencies = [
@@ -331,17 +342,6 @@ dependencies = [
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pocket-cli"
-version = "0.1.0"
-dependencies = [
- "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "pocket 0.1.3 (git+https://github.com/ozbe/rust-pocket.git)",
- "structopt 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pocket-cli"
+name = "pocket"
 version = "0.1.0"
 authors = ["ozbe <1372945+ozbe@users.noreply.github.com>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,32 @@
 
 A utility for interacting with the Pocket API.
 
+## Installation
+
+### macOS (OSX)
+
+```bash
+$ curl -L https://github.com/ozbe/pocket-cli/releases/download/v0.1.0/pocket-macos -o pocket
+$ chmod +x pocket
+$ cp pocket /usr/local/bin
+$ rm pocket
+```
+
+### Ubuntu (Linux)
+
+```bash
+$ wget https://github.com/ozbe/pocket-cli/releases/download/v0.1.0/pocket-linux -o pocket
+$ chmod +x pocket
+$ cp pocket /usr/local/bin
+$ rm pocket
+```
+
+### Windows
+
+Download the latest Windows
+[release](https://github.com/ozbe/pocket/releases) and place the executable
+in a folder that is in your $PATH.
+
 ## Compile from Source
 
 ```bash
@@ -11,12 +37,12 @@ $ git clone git@github.com:ozbe/pocket-cli.git
 $ cd pocket-cli
 $ cargo build --release
 ```
-The build output is `./target/release/pocket-cli`. Copy and execute that as you
+The build output is `./target/release/pocket`. Copy and execute that as you
 desire.
 
 ## Usage
 
-Run pocket with `pocket-cli -h` or `pocket-cli --help` to view the latest available flags, arguments, and
+Run pocket with `pocket -h` or `pocket --help` to view the latest available flags, arguments, and
 commands.
 
 ```text
@@ -50,6 +76,31 @@ SUBCOMMANDS:
     tags-replace    Replace tags
     unfavorite      Unfavorite
 ```
+
+## Releases
+
+### Create Release
+
+To create a new release, the only manual part of the process is creating
+and pushing a tag to GitHub. The following commands will create and push
+a tag. Before running the commands, be sure to update `MAJOR`, `MINOR`,
+and `PATCH` based on the current version and
+[Semantic Version](https://semver.org/) guidelines.
+
+**Create and Push Tag**
+```bash
+$ git checkout master
+$ git pull
+$ export TAG=v$(awk -F'"' '/version/ {print $2}' Cargo.toml)
+$ git tag -a $TAG
+# enter tag message
+$ git push origin $TAG
+```
+
+After pushing a new tag, the
+[Publish Workflow](.github/workflows/publish.yml) will create a
+corresponding GitHub Release and attach artifacts for each supported
+platform.
 
 ## License
 


### PR DESCRIPTION
Add CI to protect the master branch and add releases to reduce the friction of installing pocket-cli.