### PR TITLE
Fix auth login broken after addressing clippy changes.

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -87,11 +87,11 @@ impl TcpAuthServer {
 
     fn handle_connection(mut stream: TcpStream) {
         let mut buffer = [0; 512];
-        stream.read_exact(&mut buffer).unwrap();
+        stream.read(&mut buffer).unwrap();
 
         let response = format!("HTTP/1.1 200 OK\r\n\r\n{}", AUTH_SUCCESS_RESPONSE_BODY);
 
-        stream.write_all(response.as_bytes()).unwrap();
+        stream.write(response.as_bytes()).unwrap();
         stream.flush().unwrap();
     }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -84,7 +84,7 @@ impl TcpAuthServer {
             TcpAuthServer::handle_connection(stream)
         }
     }
-
+    #[allow(clippy::unused_io_amount)]
     fn handle_connection(mut stream: TcpStream) {
         let mut buffer = [0; 512];
         stream.read(&mut buffer).unwrap();


### PR DESCRIPTION
Auth login would hang when Pocket redirected back to the local server.