### PR TITLE
Add means to store and use config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "confy"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "directories 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +112,14 @@ dependencies = [
 name = "core-foundation-sys"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "directories"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "foreign-types"
@@ -322,8 +340,10 @@ name = "pocket"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "confy 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "pocket 0.1.3 (git+https://github.com/ozbe/rust-pocket.git)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -337,8 +357,8 @@ dependencies = [
  "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-native-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -480,15 +500,15 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.104"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.104"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -503,7 +523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -590,6 +610,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "traitobject"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,7 +681,7 @@ name = "url_serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -714,8 +742,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum confy 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4b1400cd0dae7f27d2c7ced9492e1398d2e2df614570092a4936c73b416dedea"
 "checksum core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 "checksum core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+"checksum directories 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc2561db021b6f1321d0f16b67ed28ce843ef4610dfaa432e3ffa2e8a3050ebf"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
@@ -759,8 +789,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum schannel 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295"
 "checksum security-framework 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "97bbedbe81904398b6ebb054b3e912f99d55807125790f3198ac990d98def5b0"
 "checksum security-framework-sys 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "06fd2f23e31ef68dd2328cc383bd493142e46107a3a0e24f7d734e3f3b80fe4c"
-"checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
-"checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
+"checksum serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
+"checksum serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 "checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 "checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
@@ -771,6 +801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4"
+confy = "0.3.1"
 hyper = "0.10.16"
 pocket = { git = "https://github.com/ozbe/rust-pocket.git" }
+serde = "1.0.111"
 structopt = "0.3"
 url = "1.0"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ rm pocket
 ### Windows
 
 Download the latest Windows
-[release](https://github.com/ozbe/pocket/releases) and place the executable
+[release](https://github.com/ozbe/pocket-cli/releases) and place the executable
 in a folder that is in your $PATH.
 
 ## Compile from Source
@@ -46,11 +46,11 @@ Run pocket with `pocket -h` or `pocket --help` to view the latest available flag
 commands.
 
 ```text
-pocket-cli 0.1.0
+pocket 0.1.0
 Interact with the Pocket API
 
 USAGE:
-    pocket-cli [OPTIONS] --consumer-key <consumer-key> <SUBCOMMAND>
+    pocket [OPTIONS] <SUBCOMMAND>
 
 FLAGS:
     -h, --help       Prints help information
@@ -64,6 +64,7 @@ SUBCOMMANDS:
     add             Add
     archive         Archive
     auth            Authenticate
+    config          Config
     delete          Delete
     favorite        Favorite
     get             Get

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -6,20 +6,25 @@ use url::Url;
 
 #[derive(Debug, StructOpt)]
 pub enum Auth {
-    Login,
+    // Login
+    Login {
+        #[structopt(long)]
+        /// Save access token to config
+        save: bool,
+    },
 }
 
 pub fn handle(cmd: &Auth, consumer_key: &str, writer: impl std::io::Write) {
     match cmd {
-        Auth::Login => {
+        Auth::Login { save } => {
             let server = TcpAuthServer::new();
             let pocket = PocketAuthentication::new(&consumer_key, server.addr());
-            login(pocket, server, writer)
+            login(pocket, save.clone(), server, writer)
         }
     }
 }
 
-fn login(pocket: impl PocketAuth, server: impl AuthServer, mut writer: impl std::io::Write) {
+fn login(pocket: impl PocketAuth, save: bool, server: impl AuthServer, mut writer: impl std::io::Write) {
     let code = pocket.request(None).unwrap();
     writeln!(
         writer,
@@ -31,8 +36,16 @@ fn login(pocket: impl PocketAuth, server: impl AuthServer, mut writer: impl std:
     server.wait_for_response();
 
     let user = pocket.authorize(&code, None).unwrap();
-    writeln!(writer, "username: {}", user.username).unwrap();
-    writeln!(writer, "access token: {:?}", user.access_token).unwrap();
+
+    if save {
+        let mut cfg = crate::config::load();
+        cfg.access_token = Some(user.access_token);
+        crate::config::store(cfg);
+        writeln!(writer, "Success!").unwrap();
+    } else {
+        writeln!(writer, "username: {}", user.username).unwrap();
+        writeln!(writer, "access token: {:?}", user.access_token).unwrap();
+    }
 }
 
 trait PocketAuth {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -19,7 +19,7 @@ pub fn handle(cmd: &Auth, consumer_key: &str, writer: impl std::io::Write) {
         Auth::Login { save } => {
             let server = TcpAuthServer::new();
             let pocket = PocketAuthentication::new(&consumer_key, server.addr());
-            login(pocket, save.clone(), server, writer)
+            login(pocket, *save, server, writer)
         }
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -161,7 +161,7 @@ mod tests {
         };
         let mut result = Vec::new();
 
-        login(pocket, server, &mut result);
+        login(pocket, false, server, &mut result);
 
         assert_eq!(
             format!(

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -24,7 +24,12 @@ pub fn handle(cmd: &Auth, consumer_key: &str, writer: impl std::io::Write) {
     }
 }
 
-fn login(pocket: impl PocketAuth, save: bool, server: impl AuthServer, mut writer: impl std::io::Write) {
+fn login(
+    pocket: impl PocketAuth,
+    save: bool,
+    server: impl AuthServer,
+    mut writer: impl std::io::Write,
+) {
     let code = pocket.request(None).unwrap();
     writeln!(
         writer,

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,22 +41,25 @@ pub fn store(cfg: Config) {
     confy::store(CFG_NAME, cfg).unwrap();
 }
 
+const CFG_KEY_CONSUMER_KEY: &str = "consumer_key";
+const CFG_KEY_ACCESS_TOKEN: &str = "access_token";
+
 pub fn handle(opts: &ConfigOpts, mut writer: impl std::io::Write) {
     let mut cfg = load();
 
     match opts {
         ConfigOpts::Get { key } => {
             let value = match key.as_str() {
-                "consumer_key" => cfg.consumer_key,
-                "access_token" => cfg.access_token,
+                CFG_KEY_CONSUMER_KEY => cfg.consumer_key,
+                CFG_KEY_ACCESS_TOKEN => cfg.access_token,
                 _ => panic!(format!("Invalid key: `{}`", key)),
             }.unwrap_or_default();
             writeln!(writer, "{}", value).unwrap();
         },
         ConfigOpts::Set { key, value } => {
             match key.as_str() {
-                "consumer_key" => cfg.consumer_key = value.clone(),
-                "access_token" => cfg.access_token = value.clone(),
+                CFG_KEY_CONSUMER_KEY => cfg.consumer_key = value.clone(),
+                CFG_KEY_ACCESS_TOKEN => cfg.access_token = value.clone(),
                 _ => panic!(format!("Invalid key: `{}`", key)),
             };
             store(cfg);

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,7 +37,7 @@ pub fn load() -> Config {
     confy::load(CFG_NAME).unwrap()
 }
 
-fn store(cfg: Config) {
+pub fn store(cfg: Config) {
     confy::store(CFG_NAME, cfg).unwrap();
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,69 @@
+use structopt::StructOpt;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, StructOpt)]
+pub enum ConfigOpts {
+    /// Get
+    Get {
+        key: String,
+    },
+    /// Set
+    Set {
+        key: String,
+        value: Option<String>,
+    },
+    /// View
+    View,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Config {
+    pub consumer_key: Option<String>,
+    pub access_token: Option<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            consumer_key: None,
+            access_token: None,
+        }
+    }
+}
+
+const CFG_NAME: &str = env!("CARGO_PKG_NAME");
+
+pub fn load() -> Config {
+    confy::load(CFG_NAME).unwrap()
+}
+
+fn store(cfg: Config) {
+    confy::store(CFG_NAME, cfg).unwrap();
+}
+
+pub fn handle(opts: &ConfigOpts, mut writer: impl std::io::Write) {
+    let mut cfg = load();
+
+    match opts {
+        ConfigOpts::Get { key } => {
+            let value = match key.as_str() {
+                "consumer_key" => cfg.consumer_key,
+                "access_token" => cfg.access_token,
+                _ => panic!(format!("Invalid key: `{}`", key)),
+            }.unwrap_or_default();
+            writeln!(writer, "{}", value).unwrap();
+        },
+        ConfigOpts::Set { key, value } => {
+            match key.as_str() {
+                "consumer_key" => cfg.consumer_key = value.clone(),
+                "access_token" => cfg.access_token = value.clone(),
+                _ => panic!(format!("Invalid key: `{}`", key)),
+            };
+            store(cfg);
+            writeln!(writer, "Success").unwrap();
+        },
+        ConfigOpts::View => {
+            writeln!(writer, "{:?}", cfg).unwrap();
+        },
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,17 +1,12 @@
-use structopt::StructOpt;
 use serde::{Deserialize, Serialize};
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub enum ConfigOpts {
     /// Get
-    Get {
-        key: String,
-    },
+    Get { key: String },
     /// Set
-    Set {
-        key: String,
-        value: Option<String>,
-    },
+    Set { key: String, value: Option<String> },
     /// View
     View,
 }
@@ -53,9 +48,10 @@ pub fn handle(opts: &ConfigOpts, mut writer: impl std::io::Write) {
                 CFG_KEY_CONSUMER_KEY => cfg.consumer_key,
                 CFG_KEY_ACCESS_TOKEN => cfg.access_token,
                 _ => panic!(format!("Invalid key: `{}`", key)),
-            }.unwrap_or_default();
+            }
+            .unwrap_or_default();
             writeln!(writer, "{}", value).unwrap();
-        },
+        }
         ConfigOpts::Set { key, value } => {
             match key.as_str() {
                 CFG_KEY_CONSUMER_KEY => cfg.consumer_key = value.clone(),
@@ -64,9 +60,9 @@ pub fn handle(opts: &ConfigOpts, mut writer: impl std::io::Write) {
             };
             store(cfg);
             writeln!(writer, "Success").unwrap();
-        },
+        }
         ConfigOpts::View => {
             writeln!(writer, "{:?}", cfg).unwrap();
-        },
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,11 @@ use structopt::StructOpt;
 
 mod add;
 mod auth;
+mod config;
 mod get;
 mod send;
 mod tag;
 mod tags;
-mod config;
 
 #[derive(Debug, StructOpt)]
 /// Interact with the Pocket API.
@@ -93,14 +93,17 @@ enum Commands {
 }
 
 fn main() {
-    let Opts { consumer_key: opt_consumer_key, access_token: opt_access_token, command } = Opts::from_args();
+    let Opts {
+        consumer_key: opt_consumer_key,
+        access_token: opt_access_token,
+        command,
+    } = Opts::from_args();
     let cfg = config::load();
-    let consumer_key= opt_consumer_key.or(cfg.consumer_key).expect("Consumer key missing.");
+    let consumer_key = opt_consumer_key
+        .or(cfg.consumer_key)
+        .expect("Consumer key missing.");
     let access_token = opt_access_token.or(cfg.access_token);
-    let pocket = || Pocket::new(
-        &consumer_key,
-        &access_token.expect("Access token missing."),
-    );
+    let pocket = || Pocket::new(&consumer_key, &access_token.expect("Access token missing."));
     let mut writer = std::io::stdout();
 
     match command {


### PR DESCRIPTION
Passing consumer_key and access_token is tedious. This work adds the means to store config values, use the config values in subsequent commands, and save auth login to config.